### PR TITLE
feat: i18n-ize dashboard + add JP translations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,76 +3,41 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.2"
 
-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
+# 基本
 gem "rails", "~> 7.0.8", ">= 7.0.8.1"
-
-# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-gem "sprockets-rails"
-
-# Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"
-
-# Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"
-
-# Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
+gem "sprockets-rails"
 gem "importmap-rails"
-
-# Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem "turbo-rails"
-
-# Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
-
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
-# Use Devise for authentication
+# 認証
 gem "devise"
 
-# Use Redis adapter to run Action Cable in production
-# gem "redis", "~> 4.0"
+# ★ 日本語化
+gem "rails-i18n"
+gem "devise-i18n"
 
-# Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
-# gem "kredis"
-
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
-
-# Reduces boot times through caching; required in config/boot.rb
+# その他
 gem "bootsnap", require: false
-
-# Use Sass to process CSS
-# gem "sassc-rails"
-
-# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem 'pry'
-  gem "debug", platforms: %i[ mri mingw x64_mingw ]
-  gem 'pry-rails'
-  gem 'pry-byebug'
+  gem "pry"
+  gem "debug", platforms: %i[mri mingw x64_mingw]
+  gem "pry-rails"
+  gem "pry-byebug"
 end
 
 group :development do
-  # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
-
-  # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
-
-  # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 end
 
 group :test do
-  # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.15.0)
+      devise (>= 4.9.0)
+      rails-i18n
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -183,6 +186,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.8.1)
       actionpack (= 7.0.8.1)
       activesupport (= 7.0.8.1)
@@ -249,6 +255,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  devise-i18n
   importmap-rails
   jbuilder
   pg (~> 1.1)
@@ -257,6 +264,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.8, >= 7.0.8.1)
+  rails-i18n
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,10 @@
 class DashboardController < ApplicationController
+  before_action :authenticate_user!
+
   def index
+    @training_sessions = current_user.training_sessions
+                                     .includes(:session_exercises)
+                                     .order(created_at: :desc)
+    @training_session  = current_user.training_sessions.build
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,51 +1,61 @@
-<h1>FitTracker Dashboard</h1>
+<h1><%= t('dashboard.title') %></h1>
 
 <div class="dashboard">
 
   <div class="user-info">
-    <h2>Welcome, <%= current_user.name %>!</h2>
-    <p>Today's date: <%= Date.today.strftime('%Y-%m-%d') %></p>
+    <% if current_user %>
+      <h2><%= t('dashboard.welcome', name: (current_user.name.presence || 'ユーザー')) %></h2>
+    <% else %>
+      <h2><%= t('dashboard.welcome_guest') %></h2>
+    <% end %>
+    <p><%= t('dashboard.today') %>: <%= l(Date.today) %></p>
   </div>
 
   <div class="new-session">
-    <h2>Add New Training Session</h2>
+    <h2><%= t('dashboard.add_new_session') %></h2>
     <%= form_with(model: @training_session, local: true) do |form| %>
       <div class="field">
-        <%= form.label :exercise %>
+        <%= form.label :exercise, t('dashboard.form.exercise') %>
         <%= form.text_field :exercise %>
       </div>
       <div class="field">
-        <%= form.label :weight %>
+        <%= form.label :weight, t('dashboard.form.weight') %>
         <%= form.number_field :weight %>
       </div>
       <div class="field">
-        <%= form.label :reps %>
+        <%= form.label :reps, t('dashboard.form.reps') %>
         <%= form.number_field :reps %>
       </div>
       <div class="actions">
-        <%= form.submit 'Add Session' %>
+        <%= form.submit t('dashboard.form.add_session_button') %>
       </div>
     <% end %>
   </div>
 
   <div class="training-records">
-    <h2>Your Training Records</h2>
+    <h2><%= t('dashboard.records.title') %></h2>
     <table>
       <thead>
         <tr>
-          <th>Date</th>
-          <th>Exercise</th>
-          <th>Weight</th>
-          <th>Reps</th>
+          <th><%= t('dashboard.records.date') %></th>
+          <th><%= t('dashboard.records.exercise') %></th>
+          <th><%= t('dashboard.records.weight') %></th>
+          <th><%= t('dashboard.records.reps') %></th>
         </tr>
       </thead>
       <tbody>
-        <% @training_sessions.each do |session| %>
+        <% if @training_sessions.present? %>
+          <% @training_sessions.each do |session| %>
+            <tr>
+              <td><%= l(session.created_at.to_date) %></td>
+              <td><%= session.exercise %></td>
+              <td><%= session.weight %></td>
+              <td><%= session.reps %></td>
+            </tr>
+          <% end %>
+        <% else %>
           <tr>
-            <td><%= session.created_at.strftime('%Y-%m-%d') %></td>
-            <td><%= session.exercise %></td>
-            <td><%= session.weight %></td>
-            <td><%= session.reps %></td>
+            <td colspan="4"><%= t('dashboard.records.empty') %></td>
           </tr>
         <% end %>
       </tbody>
@@ -53,10 +63,10 @@
   </div>
 
   <div class="statistics">
-    <h2>Your Progress</h2>
-    <p>Total sessions: <%= @training_sessions.count %></p>
-    <p>Total weight lifted: <%= @training_sessions.sum(:weight) %> kg</p>
-    <p>Average reps per session: <%= @training_sessions.average(:reps).to_f.round(2) %></p>
+    <h2><%= t('dashboard.stats.title') %></h2>
+    <p><%= t('dashboard.stats.total_sessions', count: @training_sessions.count) %></p>
+    <p><%= t('dashboard.stats.total_weight',  kg: @training_sessions.sum(:weight)) %></p>
+    <p><%= t('dashboard.stats.avg_reps',      avg: @training_sessions.average(:reps).to_f.round(2)) %></p>
   </div>
 </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,178 +1,208 @@
 ja:
   activerecord:
     models:
-      user: ユーザー
-      training_session: トレーニングセッション
-      session_exercise: セッションエクササイズ
+      user: "ユーザー"
+      training_session: "トレーニングセッション"
+      session_exercise: "セッションエクササイズ"
     attributes:
       user:
-        confirmation_sent_at: パスワード確認送信時刻
-        confirmation_token: パスワード確認用トークン
-        confirmed_at: パスワード確認時刻
-        created_at: 作成日
-        current_password: 現在のパスワード
-        current_sign_in_at: 現在のログイン時刻
-        current_sign_in_ip: 現在のログインIPアドレス
-        email: Eメール
-        encrypted_password: 暗号化パスワード
-        failed_attempts: 失敗したログイン試行回数
-        last_sign_in_at: 最終ログイン時刻
-        last_sign_in_ip: 最終ログインIPアドレス
-        locked_at: ロック時刻
-        password: パスワード
-        password_confirmation: パスワード（確認用）
-        remember_created_at: ログイン記憶時刻
-        remember_me: ログインを記憶する
-        reset_password_sent_at: パスワードリセット送信時刻
-        reset_password_token: パスワードリセット用トークン
-        sign_in_count: ログイン回数
-        unconfirmed_email: 未確認Eメール
-        unlock_token: ロック解除用トークン
-        updated_at: 更新日
+        confirmation_sent_at: "パスワード確認送信時刻"
+        confirmation_token: "パスワード確認用トークン"
+        confirmed_at: "パスワード確認時刻"
+        created_at: "作成日"
+        current_password: "現在のパスワード"
+        current_sign_in_at: "現在のログイン時刻"
+        current_sign_in_ip: "現在のログインIPアドレス"
+        email: "Eメール"
+        encrypted_password: "暗号化パスワード"
+        failed_attempts: "失敗したログイン試行回数"
+        last_sign_in_at: "最終ログイン時刻"
+        last_sign_in_ip: "最終ログインIPアドレス"
+        locked_at: "ロック時刻"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認用）"
+        remember_created_at: "ログイン記憶時刻"
+        remember_me: "ログインを記憶する"
+        reset_password_sent_at: "パスワードリセット送信時刻"
+        reset_password_token: "パスワードリセット用トークン"
+        sign_in_count: "ログイン回数"
+        unconfirmed_email: "未確認Eメール"
+        unlock_token: "ロック解除用トークン"
+        updated_at: "更新日"
       training_session:
-        date: 日付
+        date: "日付"
       session_exercise:
-        name: 種目
-        weight: 重量
-        reps: 回数
+        name: "種目"
+        weight: "重量"
+        reps: "回数"
     errors:
       models:
         training_session:
           attributes:
             date:
-              blank: 日付を入力してください。
+              blank: "日付を入力してください。"
         session_exercise:
           attributes:
             name:
-              blank: 種目を入力してください。
+              blank: "種目を入力してください。"
             weight:
-              blank: 重量を入力してください。
-              not_a_number: 重量は数値で入力してください。
+              blank: "重量を入力してください。"
+              not_a_number: "重量は数値で入力してください。"
             reps:
-              blank: 回数を入力してください。
-              not_a_number: 回数は数値で入力してください。
+              blank: "回数を入力してください。"
+              not_a_number: "回数は数値で入力してください。"
             exercise:
               required: "運動項目は必須です"
+
   devise:
     confirmations:
-      confirmed: メールアドレスが確認できました。
+      confirmed: "メールアドレスが確認できました。"
       new:
-        resend_confirmation_instructions: アカウント確認メール再送
-      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
-      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+        resend_confirmation_instructions: "アカウント確認メール再送"
+      send_instructions: "アカウントの有効化について数分以内にメールでご連絡します。"
+      send_paranoid_instructions: "メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。"
     failure:
-      already_authenticated: すでにログインしています。
-      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      already_authenticated: "すでにログインしています。"
+      inactive: "アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。"
       invalid: "%{authentication_keys}またはパスワードが違います。"
-      last_attempt: もう一回誤るとアカウントがロックされます。
-      locked: アカウントはロックされています。
+      last_attempt: "もう一回誤るとアカウントがロックされます。"
+      locked: "アカウントはロックされています。"
       not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
-      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
-      unauthenticated: ログインもしくはアカウント登録してください。
-      unconfirmed: メールアドレスの本人確認が必要です。
+      timeout: "セッションがタイムアウトしました。もう一度ログインしてください。"
+      unauthenticated: "ログインもしくはアカウント登録してください。"
+      unconfirmed: "メールアドレスの本人確認が必要です。"
     mailer:
       confirmation_instructions:
-        action: メールアドレスの確認
+        action: "メールアドレスの確認"
         greeting: "%{recipient}様"
-        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
-        subject: メールアドレス確認メール
+        instruction: "以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。"
+        subject: "メールアドレス確認メール"
       email_changed:
-        greeting: こんにちは、%{recipient}様。
-        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
-        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
-        subject: メール変更完了
+        greeting: "こんにちは、%{recipient}様。"
+        message: "メールアドレスの（%{email}）変更が完了したため、メールを送信しています。"
+        message_unconfirmed: "メールアドレスが（%{email}）変更されたため、メールを送信しています。"
+        subject: "メール変更完了"
       password_change:
         greeting: "%{recipient}様"
-        message: パスワードが再設定されました。
-        subject: パスワードの変更について
+        message: "パスワードが再設定されました。"
+        subject: "パスワードの変更について"
       reset_password_instructions:
-        action: パスワード変更
+        action: "パスワード変更"
         greeting: "%{recipient}様"
-        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
-        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
-        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
-        subject: パスワードの再設定について
+        instruction: "パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。"
+        instruction_2: "パスワード再設定の依頼をしていない場合、このメールを無視してください。"
+        instruction_3: "パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。"
+        subject: "パスワードの再設定について"
       unlock_instructions:
-        action: アカウントのロック解除
+        action: "アカウントのロック解除"
         greeting: "%{recipient}様"
-        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
-        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
-        subject: アカウントのロック解除について
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
+        subject: "アカウントのロック解除について"
     omniauth_callbacks:
       failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
       success: "%{kind} アカウントによる認証に成功しました。"
     passwords:
       edit:
-        change_my_password: パスワードを変更する
-        change_your_password: パスワードを変更
-        confirm_new_password: 確認用新しいパスワード
-        new_password: 新しいパスワード
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
       new:
-        forgot_your_password: パスワードを忘れましたか？
-        send_me_reset_password_instructions: パスワードの再設定方法を送信する
-      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
-      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
-      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
-      updated: パスワードが正しく変更されました。
-      updated_not_active: パスワードが正しく変更されました。
+        forgot_your_password: "パスワードを忘れましたか？"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
+      no_token: "このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。"
+      send_instructions: "パスワードの再設定について数分以内にメールでご連絡いたします。"
+      send_paranoid_instructions: "メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。"
+      updated: "パスワードが正しく変更されました。"
+      updated_not_active: "パスワードが正しく変更されました。"
     registrations:
-      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      destroyed: "アカウントを削除しました。またのご利用をお待ちしております。"
       edit:
-        are_you_sure: 本当によろしいですか？
-        cancel_my_account: アカウント削除
+        are_you_sure: "本当によろしいですか？"
+        cancel_my_account: "アカウント削除"
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
-        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
         title: "%{resource}編辑"
-        unhappy: 気に入りません
-        update: 更新
-        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
       new:
-        sign_up: アカウント登録
-      signed_up: アカウント登録が完了しました。
-      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
-      signed_up_but_locked: アカウントがロックされているためログインできません。
-      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
-      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
-      updated: アカウント情報を変更しました。
-      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+        sign_up: "アカウント登録"
+      signed_up: "アカウント登録が完了しました。"
+      signed_up_but_inactive: "ログインするためには、アカウントを有効化してください。"
+      signed_up_but_locked: "アカウントがロックされているためログインできません。"
+      signed_up_but_unconfirmed: "本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。"
+      update_needs_confirmation: "アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。"
+      updated: "アカウント情報を変更しました。"
+      updated_but_not_signed_in: "あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。"
     sessions:
-      already_signed_out: 既にログアウト済みです。
+      already_signed_out: "既にログアウト済みです。"
       new:
-        sign_in: ログイン
-      signed_in: ログインしました。
-      signed_out: ログアウトしました。
+        sign_in: "ログイン"
+      signed_in: "ログインしました。"
+      signed_out: "ログアウトしました。"
     shared:
       links:
-        back: 戻る
-        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
-        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
-        forgot_your_password: パスワードを忘れましたか？
-        sign_in: ログイン
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか？"
+        didn_t_receive_unlock_instructions: "アカウントのロック解除方法のメールを受け取っていませんか？"
+        forgot_your_password: "パスワードを忘れましたか？"
+        sign_in: "ログイン"
         sign_in_with_provider: "%{provider}でログイン"
-        sign_up: アカウント登録
+        sign_up: "アカウント登録"
       minimum_password_length: "（%{count}字以上）"
     unlocks:
       new:
-        resend_unlock_instructions: アカウントのロック解除方法を再送する
-      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
-      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
-      unlocked: アカウントをロック解除しました。
+        resend_unlock_instructions: "アカウントのロック解除方法を再送する"
+      send_instructions: "アカウントのロック解除方法を数分以内にメールでご連絡します。"
+      send_paranoid_instructions: "アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。"
+      unlocked: "アカウントをロック解除しました。"
+
   errors:
     messages:
-      already_confirmed: は既に登録済みです。ログインしてください。
-      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
-      expired: の有効期限が切れました。新しくリクエストしてください。
-      not_found: は見つかりませんでした。
-      not_locked: はロックされていません。
+      already_confirmed: "は既に登録済みです。ログインしてください。"
+      confirmation_period_expired: "の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。"
+      expired: "の有効期限が切れました。新しくリクエストしてください。"
+      not_found: "は見つかりませんでした。"
+      not_locked: "はロックされていません。"
       not_saved:
-        one: エラーが発生したため %{resource} は保存されませんでした。
+        one: "エラーが発生したため %{resource} は保存されませんでした。"
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+
   goals:
     created_successfully: "目標が正常に作成されました。"
     updated_successfully: "目標が正常に更新されました。"
     destroy_success: "目標が正常に削除されました。"
+
   date:
+    formats:
+      default: "%Y-%m-%d"
     order:
       - :year
       - :month
       - :day
+
+  dashboard:
+    title: "トレーニングダッシュボード"
+    welcome: "ようこそ、%{name}さん！"
+    welcome_guest: "ようこそ、ゲストさん！"
+    today: "本日の日付"
+    add_new_session: "新しいトレーニングを追加"
+    form:
+      exercise: "種目"
+      weight: "重量"
+      reps: "回数"
+      add_session_button: "追加"
+    records:
+      title: "トレーニング記録"
+      date: "日付"
+      exercise: "種目"
+      weight: "重量"
+      reps: "回数"
+      empty: "まだ記録がありません"
+    stats:
+      title: "進捗状況"
+      total_sessions: "セッション合計: %{count} 件"
+      total_weight: "総挙上重量: %{kg} kg"
+      avg_reps: "平均回数/セッション: %{avg}"


### PR DESCRIPTION
## 目的
- ダッシュボード画面の日本語対応
- Rails/Devise の標準メッセージを日本語化
- 文言をファイルに集約して保守性を向上

## 変更点
- chore(i18n): rails-i18n/devise-i18n を導入（bundle install 反映）
- feat(i18n): config/locales/ja.yml に dashboard と date formats を追加
- feat(dashboard): index.html.erb を t()/l() で i18n 化、固定英語の排除
- fix(dashboard): DashboardController#index で @training_sessions/@training_session をセット

## 動作確認
- ダッシュボードの見出し/ラベル/ボタンが日本語表示
- 日付が l() により `YYYY-MM-DD` 形式で表示
- Devise のフラッシュ/バリデーションが日本語
- `translation missing:` が出ない
