### PR TITLE
Chore/post macos update setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,4 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+gem "ruby-lsp", "~> 0.26.1", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,8 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    language_server-protocol (3.17.0.5)
+    logger (1.7.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -148,6 +150,7 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.5.6)
+    prism (1.6.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -197,6 +200,8 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.2.1)
+    rbs (3.9.5)
+      logger
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     regexp_parser (2.9.0)
@@ -206,6 +211,10 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
+    ruby-lsp (0.26.1)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 1.2, < 2.0)
+      rbs (>= 3, < 5)
     rubyzip (2.3.2)
     selenium-webdriver (4.19.0)
       base64 (~> 0.2)
@@ -265,6 +274,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.8, >= 7.0.8.1)
   rails-i18n
+  ruby-lsp (~> 0.26.1)
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/javascript/controllers/nested_form_controller.js
+++ b/app/javascript/controllers/nested_form_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["list", "template"]
+
+  add(e) {
+    e.preventDefault()
+    const html = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, Date.now().toString())
+    this.listTarget.insertAdjacentHTML("beforeend", html)
+  }
+
+  remove(e) {
+    e.preventDefault()
+    const row = e.target.closest("[data-nested-form-row]")
+    const destroy = row.querySelector("input[name*='_destroy']")
+    if (destroy) {
+      destroy.value = "1"
+      row.style.display = "none"
+    } else {
+      row.remove()
+    }
+  }
+}

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,95 +1,27 @@
-<h1><%= t('dashboard.title') %></h1>
+<h1>Dashboard</h1>
 
-<div class="dashboard">
+<nav style="margin: 12px 0;">
+  <%= link_to "記録一覧", training_sessions_path %> |
+  <%= link_to "新規記録", new_training_session_path %> |
+  <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
+</nav>
 
-  <div class="user-info">
-    <% if current_user %>
-      <h2><%= t('dashboard.welcome', name: (current_user.name.presence || 'ユーザー')) %></h2>
-    <% else %>
-      <h2><%= t('dashboard.welcome_guest') %></h2>
+<h2>最近の記録</h2>
+<% if @training_sessions.present? %>
+  <ul>
+    <% @training_sessions.each do |ts| %>
+      <li>
+        <%= link_to (ts.date || ts.created_at.to_date), training_session_path(ts) %>
+        <%# 明細を出したくなったら:
+        # <ul>
+        #   <% ts.session_exercises.includes(:exercise).each do |se| %>
+        #     <li><%= [se.try(:exercise)&.name || se.name, se.weight, se.reps].compact.join(" / ") %></li>
+        #   <% end %>
+        # </ul>
+        %>
+      </li>
     <% end %>
-    <p><%= t('dashboard.today') %>: <%= l(Date.today) %></p>
-  </div>
-
-  <div class="new-session">
-    <h2><%= t('dashboard.add_new_session') %></h2>
-    <%= form_with(model: @training_session, local: true) do |form| %>
-      <div class="field">
-        <%= form.label :exercise, t('dashboard.form.exercise') %>
-        <%= form.text_field :exercise %>
-      </div>
-      <div class="field">
-        <%= form.label :weight, t('dashboard.form.weight') %>
-        <%= form.number_field :weight %>
-      </div>
-      <div class="field">
-        <%= form.label :reps, t('dashboard.form.reps') %>
-        <%= form.number_field :reps %>
-      </div>
-      <div class="actions">
-        <%= form.submit t('dashboard.form.add_session_button') %>
-      </div>
-    <% end %>
-  </div>
-
-  <div class="training-records">
-    <h2><%= t('dashboard.records.title') %></h2>
-    <table>
-      <thead>
-        <tr>
-          <th><%= t('dashboard.records.date') %></th>
-          <th><%= t('dashboard.records.exercise') %></th>
-          <th><%= t('dashboard.records.weight') %></th>
-          <th><%= t('dashboard.records.reps') %></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% if @training_sessions.present? %>
-          <% @training_sessions.each do |session| %>
-            <tr>
-              <td><%= l(session.created_at.to_date) %></td>
-              <td><%= session.exercise %></td>
-              <td><%= session.weight %></td>
-              <td><%= session.reps %></td>
-            </tr>
-          <% end %>
-        <% else %>
-          <tr>
-            <td colspan="4"><%= t('dashboard.records.empty') %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
-
-  <div class="statistics">
-    <h2><%= t('dashboard.stats.title') %></h2>
-    <p><%= t('dashboard.stats.total_sessions', count: @training_sessions.count) %></p>
-    <p><%= t('dashboard.stats.total_weight',  kg: @training_sessions.sum(:weight)) %></p>
-    <p><%= t('dashboard.stats.avg_reps',      avg: @training_sessions.average(:reps).to_f.round(2)) %></p>
-  </div>
-</div>
-
-<style>
-  .dashboard {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-  }
-  .user-info, .new-session, .training-records, .statistics {
-    border: 1px solid #ccc;
-    padding: 20px;
-    border-radius: 10px;
-  }
-  table {
-    width: 100%;
-    border-collapse: collapse;
-  }
-  table, th, td {
-    border: 1px solid black;
-  }
-  th, td {
-    padding: 10px;
-    text-align: left;
-  }
-</style>
+  </ul>
+<% else %>
+  <p>まだ記録がありません。</p>
+<% end %>

--- a/app/views/training_sessions/_session_exercise_fields.html.erb
+++ b/app/views/training_sessions/_session_exercise_fields.html.erb
@@ -1,0 +1,49 @@
+<div data-nested-form-row style="display:flex;gap:8px;margin:6px 0;align-items:flex-end;">
+  <div>
+    <%= f.label :exercise_id, "種目" %><br>
+    <%= f.collection_select :exercise_id, Exercise.order(:name), :id, :name, include_blank: true %>
+  </div>
+  <div>
+    <%= f.label :weight, "重さ(kg)" %><br>
+    <%= f.number_field :weight, step: 0.5, min: 0 %>
+  </div>
+  <div>
+    <%= f.label :reps, "回数" %><br>
+    <%= f.number_field :reps, step: 1, min: 0 %>
+  </div>
+  <%= f.hidden_field :_destroy %>
+  <button type="button" data-action="nested-form#remove" style="margin-left:8px;">削除</button>
+</div>
+ERB'
+docker compose exec -T web bash -lc 'cat > app/views/training_sessions/new.html.erb' <<'ERB'
+<h1>新規トレーニング記録</h1>
+<%= render "shared/error_messages", object: @training_session %>
+
+<%= form_with model: @training_session, data: { controller: "nested-form" } do |f| %>
+  <div style="margin:8px 0;">
+    <%= f.label :date, "日付" %><br>
+    <%= f.date_field :date %>
+  </div>
+
+  <h3>種目</h3>
+  <div data-nested-form-target="list">
+    <%= f.fields_for :session_exercises do |se| %>
+      <%= render "session_exercise_fields", f: se %>
+    <% end %>
+  </div>
+
+  <template data-nested-form-target="template">
+    <%= f.fields_for :session_exercises, SessionExercise.new, child_index: "NEW_RECORD" do |se| %>
+      <%= render "session_exercise_fields", f: se %>
+    <% end %>
+  </template>
+
+  <div style="margin-top:12px; display:flex; gap:8px;">
+    <button type="button" data-action="nested-form#add">行を追加</button>
+    <%= f.submit "保存" %>
+  </div>
+<% end %>
+
+<p style="margin-top:8px;"><%= link_to "一覧に戻る", training_sessions_path %></p>
+ERB'
+docker compose exec web bash -lc 'bin/rails r "Rails.application.reloader.reload!; Rails.application.reload_routes!; puts :reloaded"'

--- a/app/views/training_sessions/index.html.erb
+++ b/app/views/training_sessions/index.html.erb
@@ -1,11 +1,12 @@
-<h1>トレーニング履歴</h1>
-<%= link_to 'トレーニング記録', new_training_session_path %>
-<ul>
-  <% @training_sessions.each do |session| %>
-    <li>
-      <%= link_to session.date, training_session_path(session) %>
-      <%= link_to '編集', edit_training_session_path(session) %>
-      <%= link_to '削除', training_session_path(session), method: :delete, data: { confirm: 'Are you sure?' } %>
-    </li>
-  <% end %>
-</ul>
+<h1>記録一覧</h1>
+<p><%= link_to "新規記録", new_training_session_path %></p>
+
+<% if @training_sessions.present? %>
+  <ul>
+    <% @training_sessions.each do |ts| %>
+      <li><%= link_to (ts.date || ts.created_at.to_date), training_session_path(ts) %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>記録がありません。</p>
+<% end %>

--- a/app/views/training_sessions/new.html.erb
+++ b/app/views/training_sessions/new.html.erb
@@ -1,72 +1,29 @@
-<h1>トレーニング記録</h1>
+<h1>New Training Session</h1>
+<%= render "shared/error_messages", object: @training_session %>
 
-<%= form_with(model: @training_session, local: true, data: { turbo: false }, html: { id: 'training-session-form' }) do |form| %>
-  <div class="col-md-10 col-lg-8 mx-auto">
-    <%= render 'shared/error_messages', object: @training_session %>
+<%= form_with model: @training_session, data: { controller: "nested-form" } do |f| %>
+  <div style="margin:8px 0;">
+    <%= f.label :date, "Date" %><br>
+    <%= f.date_field :date %>
+  </div>
 
-    <div class="field">
-      <%= form.label :date, "日付" %>
-      <%= form.date_field :date %>
-    </div>
+  <h3>Exercises</h3>
+  <div data-nested-form-target="list">
+    <%= f.fields_for :session_exercises do |se| %>
+      <%= render "session_exercise_fields", f: se %>
+    <% end %>
+  </div>
 
+  <template data-nested-form-target="template">
+    <%= f.fields_for :session_exercises, SessionExercise.new, child_index: "NEW_RECORD" do |se| %>
+      <%= render "session_exercise_fields", f: se %>
+    <% end %>
+  </template>
 
-    <h3>エクササイズ</h3>
-<div id="exercises-container">
-  <%= form.fields_for :session_exercises do |se| %>
-    <div class="exercise-row" data-index="0">
-      <%= se.label :exercise_id, "種目 1" %>
-      <%= se.collection_select :exercise_id, @exercises, :id, :name, { prompt: "種目を選択" } %>
-
-      <%= se.label :weight, "重量" %>
-      <%= se.number_field :weight, step: 0.5, placeholder: "重量(kg)" %>
-
-      <%= se.label :reps, "回数" %>
-      <%= se.number_field :reps, placeholder: "回数" %>
-    </div>
-  <% end %>
-</div>
-
-
-    <button type="button" id="add-exercise">エクササイズを追加</button>
-
-    <div class="actions">
-      <%= form.submit "保存" %>
-    </div>
+  <div style="margin-top:12px; display:flex; gap:8px;">
+    <button type="button" data-action="nested-form#add">Add Row</button>
+    <%= f.submit "Save" %>
   </div>
 <% end %>
 
-<%= link_to '戻る', training_sessions_path %>
-
-<%= javascript_tag do %>
-document.addEventListener('turbo:load', function() {
-  const container = document.getElementById('exercises-container');
-  let index = <%= @training_session.session_exercises.size %>;
-
-  // JS 側も [表示名, ID] にする（送るのは ID）
-  const exercises = <%= Exercise.all.collect { |e| [e.name, e.id] }.to_json.html_safe %>;
-
-  document.getElementById('add-exercise').addEventListener('click', function() {
-    // name → exercise_id に変更
-    let selectHTML = '<select name="training_session[session_exercises_attributes][' + index + '][exercise_id]" placeholder="種目を選択">';
-    selectHTML += '<option value="">種目を選択</option>';
-    exercises.forEach(function(exercise) {
-      // exercise[0] = 表示名, exercise[1] = ID
-      selectHTML += '<option value="' + exercise[1] + '">' + exercise[0] + '</option>';
-    });
-    selectHTML += '</select>';
-
-    const newExerciseHTML = `
-      <div class="exercise-row" data-index="${index}">
-        <label>種目 ${index + 1}</label>
-        ${selectHTML}
-        <label>重量</label>
-        <input type="number" step="0.5" name="training_session[session_exercises_attributes][${index}][weight]" placeholder="重量(kg)">
-        <label>回数</label>
-        <input type="number" name="training_session[session_exercises_attributes][${index}][reps]" placeholder="回数">
-      </div>
-    `;
-    container.insertAdjacentHTML('beforeend', newExerciseHTML);
-    index++;
-  });
-});
-<% end %>
+<p style="margin-top:8px;"><%= link_to "Back to List", training_sessions_path %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,21 +1,30 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  # ログイン済みはダッシュボード、未ログインはサインイン
+  authenticated :user do
+    root to: "dashboard#index", as: :authenticated_root
+  end
+  unauthenticated do
+    root to: "devise/sessions#new"
+  end
 
-  # Defines the root path route ("/")
-  root "dashboard#index"
-  get '/dashboard', to: 'dashboard#index', as: 'dashboard'
-  resources :users, only: :show
-  resources :goals
-  resources :session_exercises, only: [:create, :destroy]
+  # ダッシュボード
+  get "dashboard", to: "dashboard#index"
+
+  # 記録（標準REST）
   resources :training_sessions do
     collection do
-      get 'sessions_on_date/:date', to: 'training_sessions#sessions_on_date', as: 'sessions_on_date'
-      get '/patients/:id', to: 'patients#show'
+      # /training_sessions/sessions_on_date?date=YYYY-MM-DD
+      get :sessions_on_date
     end
-    member do
-      post 'edit', to: 'training_sessions#update' 
-    end
+    # 必要に応じてネスト
+    resources :session_exercises, only: %i[create update destroy]
   end
+
+  # プロフィール（必要なら）
+  resources :users, only: :show
+
+  # 目標
+  resources :goals
 end


### PR DESCRIPTION
## 目的
- macOS アップデート後に開発環境が崩れたため、環境系の復旧と整備。

## 変更点
- VS Code `code` コマンド導入、拡張の導入手順整備
- Ruby LSP を dev 環境に導入（Gemfile のみ）
- ルーティング整理（未使用ルート/不正なメンバールートの削除、authenticated root）
- controller の current_user スコープ化（漏れの修正）
- dashboard/index と sessions/index を安全表示に簡素化

## 動作確認
- `docker compose up -d` で起動
- demo ユーザーでログインできる
- `/training_sessions` で自分の記録のみ表示
- `/training_sessions/new` で日付を保存できる